### PR TITLE
Don't close curl object if it's not a resource

### DIFF
--- a/src/VendAPI/VendRequest.php
+++ b/src/VendAPI/VendRequest.php
@@ -46,7 +46,9 @@ class VendRequest
     public function __destruct()
     {
         // close curl nicely
-        curl_close($this->curl);
+        if (is_resource($this->curl)) {
+            curl_close($this->curl);
+        }
     }
     /**
      * set option for request, also accepts an array of key/value pairs for the first param


### PR DESCRIPTION
Check to see if this->curl is a resource before freeing it. It won't be a resource if a number of VendObjects's have been serialized and unserialized.

The following code will get customers from a cache file if present and if it is present a warning is issued. With the patch the warning is not issued.

``` php
if( is_file( 'cache.customers' ) )
{
        $customers = unserialize( file_get_contents( 'cache.customers' ) );
}
else
{
        $customers = $vend->getCustomers();
        file_put_contents( 'cache.customers', serialize( $customers ) );
}

var_dump( $customers );
```

Hope this makes sense ;)
