### PR TITLE
Support for "Too Many Requests" 429 response from Vend

### DIFF
--- a/src/VendAPI/VendRequest.php
+++ b/src/VendAPI/VendRequest.php
@@ -25,6 +25,8 @@ class VendRequest
     private $http_header;
     private $http_body;
 
+    public $http_code;
+
     public function __construct($url, $username, $password)
     {
         $this->curl = curl_init();
@@ -35,7 +37,7 @@ class VendRequest
         $options = array(
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_TIMEOUT => 120,
-            CURLOPT_FAILONERROR => 1,
+            CURLOPT_FAILONERROR => 0,    // 0 allows us to process the 400 responses (e.g. rate limits)
             CURLOPT_HTTPAUTH => CURLAUTH_ANY,
             CURLOPT_HTTPHEADER => array(
                 'Accept: application/json',
@@ -102,15 +104,15 @@ class VendRequest
         $this->setOpt(CURLOPT_URL, $this->url.$path);
 
         $this->response = $response = curl_exec($this->curl);
-
-        $header_size = curl_getinfo($this->curl, CURLINFO_HEADER_SIZE);
+        $curl_status = curl_getinfo($this->curl);
+        $this->http_code = $curl_status['http_code'];
+        $header_size = $curl_status['header_size'];
 
         $this->http_header = substr($response, 0, $header_size);
         $this->http_body = substr($response, $header_size);
 
-
         if ($this->debug) {
-            $this->curl_debug = curl_getinfo($this->curl);
+            $this->curl_debug = $status;
             $head = $foot = "\n";
             if (php_sapi_name() !== 'cli') {
                 $head = '<pre>';


### PR DESCRIPTION
Rate limit responses (see https://developers.vendhq.com/documentation/ratelimiting.html) from the Vend API would previously result in the "Recieved null result from API" exception being thrown due to CURLOPT_FAILONERROR being set. Requires system time be correct otherwise cooldown does not work properly - set allow_time_slip=false to ignore this.

Note: Added public property $http_code on VendRequest so that VendAPI can determine whether it was a 400+ result and act accordingly.