### PR TITLE
Allow data to be passed to public request method

### DIFF
--- a/src/VendAPI/VendAPI.php
+++ b/src/VendAPI/VendAPI.php
@@ -198,9 +198,9 @@ class VendAPI
      *
      * @return object returned from vend
      */
-    public function request($path)
+    public function request($path, $data = null)
     {
-        return $this->_request($path);
+        return $this->_request($path, $data);
     }
     private function apiGetProducts($path)
     {


### PR DESCRIPTION
I need to make some post requests and haven't found a way to pass data through to the private _request method. This allows $data to be passed through the public request method.